### PR TITLE
Fix race condition with short lived processes

### DIFF
--- a/main.go
+++ b/main.go
@@ -400,6 +400,10 @@ func moveCgroups(c *Context) (bool, error) {
 			log.Printf("Moving pid %s to %s\n", pid, currentFullPath)
 			err = writePid(pid, currentFullPath)
 			if err != nil {
+				if pidDied(pidInt) {
+					// Ignore if PID died between previous check and cgroup assignment
+					continue
+				}
 				return false, err
 			}
 


### PR DESCRIPTION
Ignore processes that died before they could be moved to the
expected cgroup.